### PR TITLE
Fix index.html metadata, asset paths, GTM duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,16 +5,15 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<meta name="color-scheme" content="light only" />
-		<meta name="description" content="Clearline Field Systems provides on-site IT support and field technical services to government offices and small businesses in the Albany, NY area. Services include device deployment, workstation troubleshooting, tech refresh projects, and hardware setup. The company specializes in fast, local response without relying" />
 		<meta property="og:site_name" content="Clearline Field Systems" />
 		<meta property="og:title" content="Clearline Field Systems" />
 		<meta property="og:type" content="website" />
 		<meta property="og:description" content="Clearline Field Systems provides on-site IT support and field technical services to government offices and small businesses in the Albany, NY area. Services include device deployment, workstation troubleshooting, tech refresh projects, and hardware setup. The company specializes in fast, local response without relying" />
 		<meta name="description" content="Fast, transparent IT support and PC refreshes. Registered SAM.gov vendor, ready to serve NY government and business" />
 		<link href="https://fonts.googleapis.com/css2?display=swap&family=Inter:ital,wght@0,300;0,400;1,300;1,400" rel="stylesheet" type="text/css" />
-		<link rel="icon" type="image/png" href="assets/images/favicon.png" />
-		<link rel="apple-touch-icon" href="assets/images/apple-touch-icon.png" />
-		<link rel="stylesheet" href="assets/main.css" />
+		<link rel="icon" type="image/png" href="favicon.png" />
+		<link rel="apple-touch-icon" href="apple-touch-icon.png" />
+		<link rel="stylesheet" href="main.css" />
 		<script async src="//www.googletagmanager.com/gtag/js?id=G-R1PHT8M2JS"></script>
 		<script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-R1PHT8M2JS', { 'send_page_view': false });</script>
 		<!-- qweoqwupeoiqwuewqe --><!-- ================================
@@ -32,14 +31,6 @@
 		<!-- Cloudflare email decode (safe to keep if needed) -->
 		<script defer src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script>
 		
-		<!-- Google Tag Manager -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-R1PHT8M2JS"></script>
-		<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){ dataLayer.push(arguments); }
-		gtag('js', new Date());
-		gtag('config', 'G-R1PHT8M2JS', { 'send_page_view': false });
-		</script><!-- mnbnbxmbzxmncbzxc -->
 	</head>
 	<body>
 		<div id="wrapper">
@@ -58,7 +49,7 @@
 										<!-- Logo -->
 										<a href="#home" style="display: flex; align-items: center; padding-left: 1rem;">
 										<img
-										src="https://raw.githubusercontent.com/clearlinesupport/clearline-assets/7247f35404ddcc097db02bccf1f3b56c723f576d/clearline_forced_fca501.svg"
+										src="clearline_forced_fca501.svg"
 										alt="Clearline Logo"
 										style="height: 48px; max-width: 100%; display: block; object-fit: contain;"
 										>
@@ -789,15 +780,6 @@
 										}
 										</style>
 										
-										<script async defer src="https://www.googletagmanager.com/gtag/js?id=G-R1PHT8M2JS"></script>
-										<script>
-										window.dataLayer = window.dataLayer || [];
-										function gtag(){dataLayer.push(arguments);}
-										window.addEventListener("load", () => {
-										gtag('js', new Date());
-										gtag('config', 'G-R1PHT8M2JS');
-										});
-										</script><!-- mnbnbxmbzxmncbzxc -->
 									</div>
 								</div>
 							</div>
@@ -806,12 +788,11 @@
 				</div>
 			</div>
 		</div>
-		<script src="assets/main.js"></script>
+		<script src="main.js"></script>
 		<!-- qweoqwupeoiqwuewqe --><!-- ================================
-		Script 1: Global Error Suppression & Polyfill (Embed → Footer)
+		Script 1: Polyfill (Embed → Footer)
 		===================================== -->
 		<script>
-		window.onerror = function() { return true; };
 		(function(){
 		const proto = Element.prototype;
 		const orig = proto.replaceWith;


### PR DESCRIPTION
## Summary
- fix duplicated meta description
- correct static asset paths
- use local logo file instead of remote URL
- remove redundant Google Tag Manager code
- drop global error suppression
- ensure newline at EOF

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842b38194508330b2ae8a898f4c7d72