### PR TITLE
Reduce initial layout shift

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,10 +18,12 @@
                 <meta name="twitter:title" content="Clearline Field Systems" />
                 <meta name="twitter:description" content="Clearline Field Systems delivers fast, on-site IT support, PC deployments, and tech refresh services to Albany-area government offices and small businesses. SAM.gov registered." />
 		<meta name="description" content="Fast, transparent on-site IT support and PC refreshes in Albany, NY. SAM.gov registered. Serving government and small business clients." />
-		<link href="https://fonts.googleapis.com/css2?display=swap&family=Inter:ital,wght@0,300;0,400;1,300;1,400" rel="stylesheet" type="text/css" />
+                <link rel="preload" href="https://fonts.googleapis.com/css2?display=optional&family=Inter:ital,wght@0,300;0,400;1,300;1,400" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+                <noscript><link href="https://fonts.googleapis.com/css2?display=optional&family=Inter:ital,wght@0,300;0,400;1,300;1,400" rel="stylesheet"></noscript>
 		<link rel="icon" type="image/png" href="favicon.png" />
 		<link rel="apple-touch-icon" href="apple-touch-icon.png" />
-		<link rel="stylesheet" href="main.css" />
+                <link rel="preload" href="main.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+                <noscript><link rel="stylesheet" href="main.css"></noscript>
 		<script async src="//www.googletagmanager.com/gtag/js?id=G-R1PHT8M2JS"></script>
 		<script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-R1PHT8M2JS', { 'send_page_view': false });</script>
 		<!-- qweoqwupeoiqwuewqe --><!-- ================================
@@ -56,11 +58,7 @@
 										<div class="header-inner">
 										<!-- Logo -->
 										<a href="#home" style="display: flex; align-items: center; padding-left: 1rem;">
-										<img
-										src="clearline_forced_fca501.svg"
-										alt="Clearline Logo"
-										style="height: 48px; max-width: 100%; display: block; object-fit: contain;"
-										>
+                                                                               <img src="clearline_forced_fca501.svg" alt="Clearline Logo" width="120" height="48" style="max-width: 100%; display: block; object-fit: contain;" />
 										</a>
 										
 										<!-- Toggle -->
@@ -116,6 +114,7 @@
 										color: var(--clr-text);
 										font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 										scroll-padding-top: var(--header-h);
+                                                                               padding-top: var(--header-h);
 										}
 										
 										header.full-bleed {


### PR DESCRIPTION
## Summary
- preload fonts and stylesheet to avoid render blocking
- add header height padding and define image dimensions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c74a33c88330ae76b11e6326bc18