### PR TITLE
Update README, modularize JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ To view or modify this site locally, you need:
 1. **Clone or download** this repository:
 
    ```bash
-   git clone https://github.com/<your-username>/clearlinesupport-site.git
-   cd clearlinesupport-site
+   git clone https://github.com/<your-username>/clearline-assets.git
+   cd clearline-assets
    ```
 
 2. **Verify file structure**. You should see `index.html`, `main.css`, `main.js`, and an `assets/` folder containing your logo, favicon, and social image.
@@ -291,7 +291,8 @@ in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
-… (Dont be stupid) …
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 ```
 
 ---

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-window.addEventListener('DOMContentLoaded', () => {
+function initSite() {
   const toggle = document.getElementById('menu-toggle');
   const nav = document.getElementById('main-nav');
 
@@ -6,14 +6,18 @@ window.addEventListener('DOMContentLoaded', () => {
     toggle.setAttribute('aria-expanded', toggle.checked);
   }
 
-  toggle.addEventListener('change', updateAria);
+  if (toggle) {
+    toggle.addEventListener('change', updateAria);
+  }
 
-  nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
-      toggle.checked = false;
-      updateAria();
+  if (nav) {
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        toggle.checked = false;
+        updateAria();
+      });
     });
-  });
+  }
 
   updateAria();
 
@@ -24,4 +28,12 @@ window.addEventListener('DOMContentLoaded', () => {
       alert('Form submitted (placeholder)');
     });
   }
-});
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { initSite };
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initSite);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "clearline-assets",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  }
+}

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,38 @@
+const { JSDOM } = require('jsdom');
+const { initSite } = require('../main');
+
+describe('initSite', () => {
+  let dom;
+  beforeEach(() => {
+    dom = new JSDOM(`
+      <input type="checkbox" id="menu-toggle">
+      <nav id="main-nav"><a href="#"></a></nav>
+      <form id="contact-form"></form>
+    `, { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+  });
+
+  it('updates aria-expanded on toggle change', () => {
+    initSite();
+    const toggle = document.getElementById('menu-toggle');
+    toggle.checked = true;
+    toggle.dispatchEvent(new dom.window.Event('change'));
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('closes menu when nav link clicked', () => {
+    initSite();
+    const toggle = document.getElementById('menu-toggle');
+    toggle.checked = true;
+    const link = document.querySelector('#main-nav a');
+    link.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    expect(toggle.checked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix clone path in README
- update MIT license section wording
- export an `initSite` function in main.js and handle missing elements
- add Jest setup with jsdom tests for navigation

## Testing
- `npm install`
- `npm test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842f41066a083309f9bdab259c88167